### PR TITLE
Optimize rendering performance and improve DX

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ function connectedCallback() {
 }
 
 function attributeChangedCallback(name, oldValue, newValue) {
+	if (!this._vdom) return;
 	const props = {};
 	props[name] = newValue;
 	this._vdom = cloneElement(this._vdom, props);


### PR DESCRIPTION
Optimize rendering performance by skipping subtree to VDOM conversion when we know only an attribute changed. Add support for specifying `tagName` and `observedAttributes` directly on the Preact Component in addition to `register()` callsite:

```js
register(class extends Component {
  static tagName = 'x-foo';
  static observedAttributes = ['a', 'b'];
  render({ a, b }) {
    return <div>{a}{b}</div>;
  }
})
```

Also, if no observedAttributes are specified, tries to pull keys from propTypes. You can ignore proptype validation and just specify the keys:

```js
register(class {
  static tagName = 'x-foo';
  static propTypes = {
    foo: Boolean  // a PropType that always validates
  };
  render({ foo }) { }
})
```

Here's both running on JSFiddle: https://jsfiddle.net/developit/0a86jf1m/

This also closes #17 and closes #18 (see [fixed repro](https://codesandbox.io/s/preact-custom-element-rendering-content-issue-vyj8s))