### PR TITLE
Dynamically generate reflected property bindings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,14 @@ export default function register(Component, tagName, propNames) {
 	PreactElement.prototype.connectedCallback = connectedCallback;
 	PreactElement.prototype.attributeChangedCallback = attributeChangedCallback;
 	PreactElement.prototype.detachedCallback = detachedCallback;
-	PreactElement.observedAttributes = propNames || Component.observedAttributes || Object.keys(Component.propTypes || {});
+	propNames = propNames || Component.observedAttributes || Object.keys(Component.propTypes || {});
+	PreactElement.observedAttributes = propNames;
+	propNames.forEach(name => {
+		Object.defineProperty(PreactElement.prototype, name, {
+			get() { return this._vdom.props[name]; },
+			set(v) { this.attributeChangedCallback(name, null, v); }
+		});
+	})
 
 	return customElements.define(
 		tagName || Component.tagName || Component.displayName || Component.name,


### PR DESCRIPTION
This makes the elements produced by preact-custom-element much nicer to deal with, and also improves rendering performance when Preact is used to render the Custom Elements.

```js
function Greeting({ name }) {
  return <span>Hello, {name}!</span>
}
register(Greeting, 'x-greeting', ['name']);

const greet = document.createElement('x-greeting');
greet.name = 'User';
document.body.appendChild(greet);
document.body.innerHTML  // <x-greeting>Hello, User!</x-greeting>
```

Notice that the property-based updates don't automatically reflect to attributes. This is done to avoid accidentally reflecting sensitive properties (think `input.value`). The reverse _does_ work, however:

```js
greet.setAttribute('name', 'Foo');
greet.name  // "Foo"
```

This change should, to the extent possible, fix #14. It is now possible to pass event handler callbacks using imperative DOM:

```js
function Image({ src, callback }) {
  return <img src={src} onload={callback} />
}
register(Image, 'x-image', ['src', 'callback']);

const img = document.createElement('x-image');
img.src = 'https://example.com/dog.jpg';
img.callback = () => console.log('loaded!');
document.body.appendChild(img);
```