### PR TITLE
Feature: adding ability to emit custom events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,25 @@ export default function register(Component, tagName, propNames, options) {
 		inst._vdomComponent = Component;
 		inst._root =
 			options && options.shadow ? inst.attachShadow({ mode: 'open' }) : inst;
+
+		inst._customEvents = {};
+		const customEvents =
+			options && (options.customEvents || Component.customEvents);
+		if (customEvents) {
+			Object.keys(customEvents).forEach((eventName) => {
+				// external event name can be provided, defaults to convention of "(on)EventName"
+				const emitName = customEvents[eventName] || eventName.slice(2);
+				const handler = (payload) => inst.dispatch(emitName, payload);
+				// later to propagate to props
+				inst._customEvents[eventName] = handler;
+				Object.defineProperty(inst, eventName, {
+					get() {
+						return handler;
+					},
+				});
+			});
+		}
+
 		return inst;
 	}
 	PreactElement.prototype = Object.create(HTMLElement.prototype);
@@ -13,6 +32,7 @@ export default function register(Component, tagName, propNames, options) {
 	PreactElement.prototype.connectedCallback = connectedCallback;
 	PreactElement.prototype.attributeChangedCallback = attributeChangedCallback;
 	PreactElement.prototype.disconnectedCallback = disconnectedCallback;
+	PreactElement.prototype.dispatch = dispatch;
 
 	propNames =
 		propNames ||
@@ -78,7 +98,7 @@ function connectedCallback() {
 
 	this._vdom = h(
 		ContextProvider,
-		{ ...this._props, context },
+		{ ...this._props, ...this._customEvents, context },
 		toVdom(this, this._vdomComponent)
 	);
 	(this.hasAttribute('hydrate') ? hydrate : render)(this._vdom, this._root);
@@ -160,4 +180,22 @@ function toVdom(element, nodeName) {
 	// Only wrap the topmost node with a slot
 	const wrappedChildren = nodeName ? h(Slot, null, children) : children;
 	return h(nodeName || element.nodeName.toLowerCase(), props, wrappedChildren);
+}
+
+function dispatch(eventName, payload) {
+	return new Promise((resolve, reject) => {
+		const callback = (result, error) => {
+			if (error !== undefined) {
+				reject(error);
+				return;
+			}
+			resolve(result);
+		};
+		this.dispatchEvent(
+			new CustomEvent(eventName, {
+				bubbles: true,
+				detail: { callback, payload },
+			})
+		);
+	});
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,10 @@ export default function register(Component, tagName, propNames, options) {
 
 		inst._customEvents = {};
 		const customEvents =
-			options && (options.customEvents || Component.customEvents);
+			(options && options.customEvents) || Component.customEvents;
 		if (customEvents) {
 			Object.keys(customEvents).forEach((eventName) => {
-				// external event name can be provided, defaults to convention of "(on)EventName"
-				const emitName = customEvents[eventName] || eventName.slice(2);
+				const emitName = customEvents[eventName] || eventName;
 				const handler = (payload) => inst.dispatch(emitName, payload);
 				// later to propagate to props
 				inst._customEvents[eventName] = handler;

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -134,9 +134,9 @@ describe('web components', () => {
 
 	describe('Custom Events', () => {
 		function DummyEvented({ onMyEvent, onMyEventSuccess, onMyEventFailed }) {
-			const clickHandler = () => {
+			function clickHandler() {
 				onMyEvent('payload').then(onMyEventSuccess, onMyEventFailed);
-			};
+			}
 			return (
 				<div>
 					<button onClick={clickHandler}>click</button>
@@ -157,7 +157,11 @@ describe('web components', () => {
 
 		registerElement(DummyEvented, 'x-dummy-evented1');
 
-		it('should allow you to expose custom events', (done) => {
+		it('should allow you to expose custom events', async () => {
+			let done;
+			const promise = new Promise((resolve) => {
+				done = resolve;
+			});
 			const el = document.createElement('x-dummy-evented');
 			root.appendChild(el);
 
@@ -168,10 +172,15 @@ describe('web components', () => {
 
 			act(() => {
 				el.querySelector('button').click();
+				return promise;
 			});
 		});
 
-		it('should enable async events (resolved)', (done) => {
+		it('should enable async events (resolved)', async () => {
+			let done;
+			const promise = new Promise((resolve) => {
+				done = resolve;
+			});
 			const el = document.createElement('x-dummy-evented');
 			root.appendChild(el);
 
@@ -187,10 +196,15 @@ describe('web components', () => {
 
 			act(() => {
 				el.querySelector('button').click();
+				return promise;
 			});
 		});
 
-		it('should enable async events (rejected)', (done) => {
+		it('should enable async events (rejected)', async () => {
+			let done;
+			const promise = new Promise((resolve) => {
+				done = resolve;
+			});
 			const el = document.createElement('x-dummy-evented');
 			root.appendChild(el);
 
@@ -206,10 +220,15 @@ describe('web components', () => {
 
 			act(() => {
 				el.querySelector('button').click();
+				return promise;
 			});
 		});
 
-		it('should allow you to expose custom events via the static property', (done) => {
+		it('should allow you to expose custom events via the static property', async () => {
+			let done;
+			const promise = new Promise((resolve) => {
+				done = resolve;
+			});
 			const el = document.createElement('x-dummy-evented1');
 			root.appendChild(el);
 
@@ -220,6 +239,7 @@ describe('web components', () => {
 
 			act(() => {
 				el.querySelector('button').click();
+				return promise;
 			});
 		});
 	});

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -132,7 +132,7 @@ describe('web components', () => {
 		});
 	});
 
-	describe('DOM Events', () => {
+	describe('Custom Events', () => {
 		function DummyEvented({ onMyEvent, onMyEventSuccess, onMyEventFailed }) {
 			const clickHandler = () => {
 				onMyEvent('payload').then(onMyEventSuccess, onMyEventFailed);
@@ -146,9 +146,16 @@ describe('web components', () => {
 		const onMyEvent = 'myEvent';
 		const onMyEventSuccess = 'myEventSuccess';
 		const onMyEventFailed = 'myEventFailed';
+		DummyEvented.customEvents = {
+			onMyEvent,
+			onMyEventSuccess,
+			onMyEventFailed,
+		};
 		registerElement(DummyEvented, 'x-dummy-evented', [], {
 			customEvents: { onMyEvent, onMyEventSuccess, onMyEventFailed },
 		});
+
+		registerElement(DummyEvented, 'x-dummy-evented1');
 
 		it('should allow you to expose custom events', (done) => {
 			const el = document.createElement('x-dummy-evented');
@@ -194,6 +201,20 @@ describe('web components', () => {
 
 			el.addEventListener(onMyEventFailed, (e) => {
 				assert.equal(e.detail.payload, 'failed!');
+				done();
+			});
+
+			act(() => {
+				el.querySelector('button').click();
+			});
+		});
+
+		it('should allow you to expose custom events via the static property', (done) => {
+			const el = document.createElement('x-dummy-evented1');
+			root.appendChild(el);
+
+			el.addEventListener(onMyEvent, (e) => {
+				assert.equal(e.detail.payload, 'payload');
 				done();
 			});
 

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -132,6 +132,77 @@ describe('web components', () => {
 		});
 	});
 
+	describe('DOM Events', () => {
+		function DummyEvented({ onMyEvent, onMyEventSuccess, onMyEventFailed }) {
+			const clickHandler = () => {
+				onMyEvent('payload').then(onMyEventSuccess, onMyEventFailed);
+			};
+			return (
+				<div>
+					<button onClick={clickHandler}>click</button>
+				</div>
+			);
+		}
+		const onMyEvent = 'myEvent';
+		const onMyEventSuccess = 'myEventSuccess';
+		const onMyEventFailed = 'myEventFailed';
+		registerElement(DummyEvented, 'x-dummy-evented', [], {
+			customEvents: { onMyEvent, onMyEventSuccess, onMyEventFailed },
+		});
+
+		it('should allow you to expose custom events', (done) => {
+			const el = document.createElement('x-dummy-evented');
+			root.appendChild(el);
+
+			el.addEventListener(onMyEvent, (e) => {
+				assert.equal(e.detail.payload, 'payload');
+				done();
+			});
+
+			act(() => {
+				el.querySelector('button').click();
+			});
+		});
+
+		it('should enable async events (resolved)', (done) => {
+			const el = document.createElement('x-dummy-evented');
+			root.appendChild(el);
+
+			el.addEventListener(onMyEvent, (e) => {
+				const callback = e.detail.callback;
+				callback('success');
+			});
+
+			el.addEventListener(onMyEventSuccess, (e) => {
+				assert.equal(e.detail.payload, 'success');
+				done();
+			});
+
+			act(() => {
+				el.querySelector('button').click();
+			});
+		});
+
+		it('should enable async events (rejected)', (done) => {
+			const el = document.createElement('x-dummy-evented');
+			root.appendChild(el);
+
+			el.addEventListener(onMyEvent, (e) => {
+				const callback = e.detail.callback;
+				callback(null, 'failed!');
+			});
+
+			el.addEventListener(onMyEventFailed, (e) => {
+				assert.equal(e.detail.payload, 'failed!');
+				done();
+			});
+
+			act(() => {
+				el.querySelector('button').click();
+			});
+		});
+	});
+
 	function Foo({ text, children }) {
 		return (
 			<span class="wrapper">


### PR DESCRIPTION
this will allow via configuration the addition of custom events that can be fired outside of the Preact world and consumed by the host page. they include a callback in the event payload in case you want async events (like if you let the host page take care of server calls by request from the component)