### PR TITLE
Allow creating a CustomElement without defining the tagName

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ FullName.propTypes = {
 register(FullName, 'full-name');
 ```
 
+### Creating a CustomElements without registering a tag name
+
+If authoring a custom-elements library, you might want to expose your CustomElements without registering their tag name, to let your users register their own tags.
+
+This can be achieved by calling the `toCustomElements` function on the default export:
+
+```js
+import register from 'preact-custom-element'
+
+function MyComponent({ name = "World" }) {
+  return <span>Hello {name}!</span>  
+}
+
+export const MyElement = register.toCustomElement(MyComponent, ['name'])
+```
+
+`toCustomElement` has the same signature as `register`, omitting the second parameter (tag name).
 
 ## Related
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { h, cloneElement, render, hydrate } from 'preact';
 
-export default function register(Component, tagName, propNames, options) {
+function toCustomElement(Component, propNames, options) {
 	function PreactElement() {
 		const inst = Reflect.construct(HTMLElement, [], PreactElement);
 		inst._vdomComponent = Component;
@@ -49,11 +49,19 @@ export default function register(Component, tagName, propNames, options) {
 		});
 	});
 
+	return PreactElement;
+}
+
+export default function register(Component, tagName, propNames, options) {
+	const PreactElement = toCustomElement(Component, propNames, options);
+
 	return customElements.define(
 		tagName || Component.tagName || Component.displayName || Component.name,
 		PreactElement
 	);
 }
+
+register.toCustomElement = toCustomElement;
 
 function ContextProvider(props) {
 	this.getChildContext = () => props.context;

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -245,4 +245,32 @@ describe('web components', () => {
 		});
 		assert.equal(getShadowHTML(), '<p>Active theme: sunny</p>');
 	});
+
+	function ManualRegistration() {
+		return <div>I'm manually registered</div>;
+	}
+
+	it('allows manual deferred registration by just exposing the element', async () => {
+		const CustomElement = registerElement.toCustomElement(
+			ManualRegistration,
+			[],
+			{ shadow: false }
+		);
+
+		const el = document.createElement('x-manually-registered');
+
+		root.appendChild(el);
+		assert.equal(
+			root.innerHTML,
+			'<x-manually-registered></x-manually-registered>'
+		);
+
+		window.customElements.define('x-manually-registered', CustomElement);
+
+		root.appendChild(el);
+		assert.equal(
+			root.innerHTML,
+			"<x-manually-registered><div>I'm manually registered</div></x-manually-registered>"
+		);
+	});
 });


### PR DESCRIPTION
## What does this PR do

The goal of this PR is to separate the Preact-to-CustomElement process from the tag-name registration process.

## Why is this PR needed

Registering a CustomElement using `window.customElements.define` uses a shared, global registry for custom-elements. Thus, only one CustomElement can be associated with a given tag-name. This can cause problems when authoring a component library: we "reserve" keywords on behalf of our end users. It also causes isolation issue for patterns such a micro-frontend architecture, where two versions of our library can't be used together, as they would clash while registering components.

## Implementation details

This PR moves all the creation of `PreactElement` into its own function, `toCustomElement`. This function takes the same parameters as the default `register` export, omitting the second parameter (tag name).

The default exports is unchanged, and still registers the element right away.

Usage is as follow:

```js
import register from 'preact-custom-element'

function MyComponent({ name = "World" }) {
  return <span>Hello {name}!</span>  
}

// Usage 1: Register the element right away (default)
register(MyComponent, "my-component", ['name'])


// Usage 2: Create the element, but do not register it
export const MyElement = register.toCustomElement(MyComponent, ['name'])

// Users can later do their own window.customElements.define('some-lib-element', MyElement)
```

## Misc

Right now the `toCustomElement` function is attached as a property of `register`, as to not introduce a named export next to the default one (microbundle was not happy with that). However it's not the most elegant thing. We could maybe introduce a new option to the `register` function, called `define`: `boolean, defaults to "true": whether to define the element after creating it. If false, the customElement will be returned instead of being defined`