### PR TITLE
Allow static children in shadow: false mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,13 @@ export default function register(Component, tagName, propNames, options) {
 	propNames.forEach((name) => {
 		Object.defineProperty(PreactElement.prototype, name, {
 			get() {
-				return this._vdom.props[name];
+				if (this._vdom) {
+					return this._vdom.props[name];
+				}
+
+				if (!this._props) this._props = {};
+
+				return this._props[name];
 			},
 			set(v) {
 				if (this._vdom) {
@@ -35,7 +41,7 @@ export default function register(Component, tagName, propNames, options) {
 				} else {
 					if (!this._props) this._props = {};
 					this._props[name] = v;
-					this.connectedCallback();
+					this._props[toCamelCase(name)] = v;
 				}
 
 				// Reflect property changes to attributes if the value is a primitive

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,16 @@
-import { h, cloneElement, render, hydrate } from 'preact';
+import { h, Fragment, cloneElement, render, hydrate } from 'preact';
 
 export default function register(Component, tagName, propNames, options) {
 	function PreactElement() {
 		const inst = Reflect.construct(HTMLElement, [], PreactElement);
 		inst._vdomComponent = Component;
-		inst._root =
-			options && options.shadow ? inst.attachShadow({ mode: 'open' }) : inst;
+		inst._shadowEnabled = options && options.shadow;
+		inst._root = inst._shadowEnabled
+			? inst.attachShadow({ mode: 'open' })
+			: inst;
 		return inst;
 	}
+
 	PreactElement.prototype = Object.create(HTMLElement.prototype);
 	PreactElement.prototype.constructor = PreactElement;
 	PreactElement.prototype.connectedCallback = connectedCallback;
@@ -79,7 +82,7 @@ function connectedCallback() {
 	this._vdom = h(
 		ContextProvider,
 		{ ...this._props, context },
-		toVdom(this, this._vdomComponent)
+		toVdom(this, this._vdomComponent, this._shadowEnabled)
 	);
 	(this.hasAttribute('hydrate') ? hydrate : render)(this._vdom, this._root);
 }
@@ -114,9 +117,11 @@ function disconnectedCallback() {
  * after having fired the event.
  */
 function Slot(props, context) {
+	const { shadow, addContextListener, removeContextListener, ...rest } = props;
+
 	const ref = (r) => {
 		if (!r) {
-			this.ref.removeEventListener('_preact', this._listener);
+			removeContextListener(this._listener, this.ref);
 		} else {
 			this.ref = r;
 			if (!this._listener) {
@@ -124,14 +129,23 @@ function Slot(props, context) {
 					event.stopPropagation();
 					event.detail.context = context;
 				};
-				r.addEventListener('_preact', this._listener);
+				addContextListener(this._listener, this.ref);
 			}
 		}
 	};
-	return h('slot', { ...props, ref });
+
+	if (!shadow && !this._listener) {
+		this._listener = (event) => {
+			event.stopPropagation();
+			event.detail.context = context;
+		};
+		addContextListener(this._listener);
+	}
+
+	return h(shadow ? 'slot' : Fragment, { ...rest, ref });
 }
 
-function toVdom(element, nodeName) {
+function toVdom(element, nodeName, shadow) {
 	if (element.nodeType === 3) return element.data;
 	if (element.nodeType !== 1) return null;
 	let children = [],
@@ -147,17 +161,46 @@ function toVdom(element, nodeName) {
 	}
 
 	for (i = cn.length; i--; ) {
-		const vnode = toVdom(cn[i], null);
+		const vnode = toVdom(cn[i], null, shadow);
 		// Move slots correctly
 		const name = cn[i].slot;
 		if (name) {
-			props[name] = h(Slot, { name }, vnode);
+			props[name] = h(
+				Slot,
+				{
+					name,
+					shadow,
+					addContextListener(listener, element = cn[i]) {
+						element.addEventListener('_preact', listener);
+					},
+					removeContextListener(listener, element = cn[i]) {
+						element.removeEventListener('_preact', listener);
+					},
+				},
+				vnode
+			);
 		} else {
 			children[i] = vnode;
 		}
 	}
 
 	// Only wrap the topmost node with a slot
-	const wrappedChildren = nodeName ? h(Slot, null, children) : children;
+	const wrappedProps = {
+		shadow,
+		addContextListener(listener, e = element) {
+			e.addEventListener('_preact', listener);
+		},
+		removeContextListener(listener, e = element) {
+			e.removeEventListener('_preact', listener);
+		},
+	};
+
+	const wrappedChildren = nodeName ? h(Slot, wrappedProps, children) : children;
+
+	// Remove all children from the topmost node in non-shadow mode
+	if (!shadow && nodeName) {
+		element.innerHTML = '';
+	}
+
 	return h(nodeName || element.nodeName.toLowerCase(), props, wrappedChildren);
 }

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -212,6 +212,9 @@ describe('web components', () => {
 	}
 
 	registerElement(DisplayTheme, 'x-display-theme', [], { shadow: true });
+	registerElement(DisplayTheme, 'x-display-theme-no-shadow', [], {
+		shadow: false,
+	});
 
 	function Parent({ children, theme = 'dark' }) {
 		return (
@@ -222,6 +225,7 @@ describe('web components', () => {
 	}
 
 	registerElement(Parent, 'x-parent', ['theme'], { shadow: true });
+	registerElement(Parent, 'x-parent-no-shadow', ['theme'], { shadow: false });
 
 	it('passes context over custom element boundaries', async () => {
 		const el = document.createElement('x-parent');
@@ -244,5 +248,54 @@ describe('web components', () => {
 			el.setAttribute('theme', 'sunny');
 		});
 		assert.equal(getShadowHTML(), '<p>Active theme: sunny</p>');
+	});
+
+	it('passes context over custom element boundaries (no shadow)', async () => {
+		const el = document.createElement('x-parent-no-shadow');
+
+		const noSlot = document.createElement('x-display-theme-no-shadow');
+		el.appendChild(noSlot);
+
+		root.appendChild(el);
+		assert.equal(
+			root.innerHTML,
+			'<x-parent-no-shadow><div class="children"><x-display-theme-no-shadow><p>Active theme: dark</p></x-display-theme-no-shadow></div></x-parent-no-shadow>'
+		);
+
+		const getDisplayThemeHTML = () =>
+			document.querySelector('x-display-theme-no-shadow').innerHTML;
+		assert.equal(getDisplayThemeHTML(), '<p>Active theme: dark</p>');
+
+		// Trigger context update
+		act(() => {
+			el.setAttribute('theme', 'sunny');
+		});
+		assert.equal(getDisplayThemeHTML(), '<p>Active theme: sunny</p>');
+	});
+
+	function NoShadow({ children }) {
+		return <div class="children">{children}</div>;
+	}
+
+	registerElement(NoShadow, 'x-no-shadow-parent', [], { shadow: false });
+
+	registerElement(NoShadow, 'x-no-shadow-children', [], { shadow: false });
+
+	it('correctly draws children without shadow', async () => {
+		const el = document.createElement('x-no-shadow-parent');
+
+		const elementChildren = document.createElement('x-no-shadow-children');
+
+		const spanChildren = document.createElement('span');
+		spanChildren.innerHTML = 'hello world';
+
+		elementChildren.appendChild(spanChildren);
+		el.appendChild(elementChildren);
+
+		root.appendChild(el);
+		assert.equal(
+			root.innerHTML,
+			'<x-no-shadow-parent><div class="children"><x-no-shadow-children><div class="children"><span>hello world</span></div></x-no-shadow-children></div></x-no-shadow-parent>'
+		);
 	});
 });


### PR DESCRIPTION
## What does this PR do

This PR allows passing children for elements even with `shadow: false`. It only works for first render, if the children are modified after first render (i.e. if the element is used in a framework such as LitElement), children are not updated.

It also cleans up the overall usage with `shadow: false` by getting rid of the `<slot>` wrapper element, attaching the `context` event listener on the custom element itself.

## Why is this PR needed

It partly fixes #41.
Children are a big part of a component design, not being able to pass children is a strong limitation. As of now, passing children results in them being duplicated. With this PR, at least the initial rendering is correct. It also enables internally handled children to be hydrated when using SSR. 

Taking the following example:

```js
function MyComponent({ children }) {
  return (
    <div class="children-go-here">
       {children}
    </div>
  )
}

register(MyComponent, 'my-component', [], { shadow: false })
```
```html
<my-component>Hello World!</my-component>
```

The resulting markup _without this PR_ is:

```html
<my-component>
   <!-- correctly rendered component -->
   <div class="children-go-here">
      Hello World!
   </div>
   <!-- incorrectly kept initial children -->
   Hello World!
</my-component>
```

_With this PR_, it becomes:

```html
<my-component>
   <!-- correctly rendered component -->
   <div class="children-go-here">
      Hello World!
   </div>
   <!-- correctly cleaned-up initial children -->
</my-component>
```

## Implementation details

This PR touches at various points of the wrapper's lifecycle. The first breaking change here is the addition of the following in `toVdom`:

```js
	// Remove all children from the topmost node in non-shadow mode
	if (!shadow && nodeName) {
		element.innerHTML = '';
	}
```

This snippet removes all children present in the original element before rendering (and after having copied them to the vDom's children), thus removing the duplicated/wrongly placed children.

The PR also removes the manual call to `connectedCallback` when handling props update before initial render. In place, it stores the props in the `_props` temporary variable, so that they are applied at first render. This allows to avoid a bug where the component is rendered inside itself when `connectedCallback` is called multiple time.

The rest is implementation details about removing the `<slot>` element when not using ShadowDOM, has it is not needed.

## Misc

Removing the `<slot>` wrapper when not using ShadowDOM allows for a cleaner DOM, but it does come at a cost: we loose the ability to _unregister_ the `_preact` event listener. We could add this ability back by using a `useEffect` hook in the `Slot` component, but I did not want to add a dependency on `preact/hooks` there, since the library seems to avoid it.

The usage is also a bit strange since modifying the children of the custom elements _will not_ update the children of the Component, since it does not call `attributeChangedCallback`. I've not found a way around this.

Finally, maybe handling children with non ShadowDOM is _not something you want to be allowed_, in which case this PR can just be closed 🙂 