### PR TITLE
feat: inject template styles to shadow dom

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,27 @@
 import { h, cloneElement, render, hydrate } from 'preact';
 
 export default function register(Component, tagName, propNames, options) {
+	const resolvedTagName =
+		tagName || Component.tagName || Component.displayName || Component.name;
+
 	function PreactElement() {
 		const inst = Reflect.construct(HTMLElement, [], PreactElement);
 		inst._vdomComponent = Component;
 		inst._root =
 			options && options.shadow ? inst.attachShadow({ mode: 'open' }) : inst;
+
+		let template = document.getElementById(`${resolvedTagName}-styles`);
+		if (!template && options && options.styles) {
+			template = document.createElement('template');
+			template.id = `${resolvedTagName}-styles`;
+			template.innerHTML = `<style id='${resolvedTagName}-styles-tag'>${options.styles}</style>`;
+			document.head.appendChild(template.cloneNode(true));
+		}
+
+		if (template) {
+			inst._root.appendChild(template.content.cloneNode(true));
+		}
+
 		return inst;
 	}
 	PreactElement.prototype = Object.create(HTMLElement.prototype);
@@ -49,10 +65,7 @@ export default function register(Component, tagName, propNames, options) {
 		});
 	});
 
-	return customElements.define(
-		tagName || Component.tagName || Component.displayName || Component.name,
-		PreactElement
-	);
+	return customElements.define(resolvedTagName, PreactElement);
 }
 
 function ContextProvider(props) {


### PR DESCRIPTION
### What does this PR do
The goal of this PR is to allow the use of shadow dom and still be able to style elements and children via "normal" classnames. 

### Why is this PR needed
As web components with shadow dom are isolated, global styles do not apply, the styles need to be available inside the components shadow dom. 
This PR adds the possibility to pass styles to the `options` object of the `register` method. If given styles, the method appends a `<template>` element (if it does not exist already) with the given styles to the `<head>` and  appends a copy to the components `_root`.

### Example
I've created an example to showcase the feature [CodeSandbox preact-custom-element style-injection](https://codesandbox.io/s/preact-custom-element-style-template-injection-pkbb9?file=/src/index.js)
