### PR TITLE
Duplicating children fix for {shadow: false}

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,9 @@ function connectedCallback() {
 		{ ...this._props, context },
 		toVdom(this, this._vdomComponent)
 	);
+
+	// rendering to clear node
+	this.innerHTML = "";
 	(this.hasAttribute('hydrate') ? hydrate : render)(this._vdom, this._root);
 }
 


### PR DESCRIPTION
When shadowDOM is not attached and developer wants to render children inside react component it will lead to duplicating of children.
1) Children will be placed at slot as intended 
2) Children will remain at the and of the node, because after rendering original content won't be cleared