### PR TITLE
Mirror component properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,19 @@
 import { h, cloneElement, render, hydrate } from 'preact';
 
+const lifecycleMethods = [
+	'componentWillMount',
+	'componentDidMount',
+	'componentWillUnmount',
+	'componentWillReceiveProps',
+	'getDerivedStateFromProps',
+	'shouldComponentUpdate',
+	'componentWillUpdate',
+	'getSnapshotBeforeUpdate',
+	'componentDidUpdate	',
+];
+
+const apiMethods = ['render'];
+
 export default function register(Component, tagName, propNames, options) {
 	function PreactElement() {
 		const inst = Reflect.construct(HTMLElement, [], PreactElement);
@@ -15,15 +29,16 @@ export default function register(Component, tagName, propNames, options) {
 	PreactElement.prototype.attributeChangedCallback = attributeChangedCallback;
 	PreactElement.prototype.disconnectedCallback = disconnectedCallback;
 
-	// b \ a
-	// take all Component properties and remove existing PreactElement properties
-	const a = new Set(Object.getOwnPropertyNames(PreactElement.prototype));
-	const b = new Set(Object.getOwnPropertyNames(Component.prototype));
-	const diff = Array.from(new Set([...b].filter((x) => !a.has(x))));
+	const methods = Object.getOwnPropertyNames(Component.prototype)
+		.filter((propertyName) => !lifecycleMethods.includes(propertyName))
+		.filter((propertyName) => !apiMethods.includes(propertyName))
+		.filter(
+			(propertyName) => typeof Component.prototype[propertyName] === 'function'
+		);
 
-	PreactElement.prototype = diff.reduce((acc, propertyName) => {
-		acc[propertyName] = Component.prototype[propertyName];
-		return acc;
+	PreactElement.prototype = methods.reduce((el, propertyName) => {
+		el[propertyName] = Component.prototype[propertyName];
+		return el;
 	}, PreactElement.prototype);
 
 	propNames =

--- a/src/index.js
+++ b/src/index.js
@@ -15,11 +15,10 @@ export default function register(Component, tagName, propNames, options) {
 	PreactElement.prototype.attributeChangedCallback = attributeChangedCallback;
 	PreactElement.prototype.disconnectedCallback = disconnectedCallback;
 
+	// b \ a
+	// take all Component properties and remove existing PreactElement properties
 	const a = new Set(Object.getOwnPropertyNames(PreactElement.prototype));
 	const b = new Set(Object.getOwnPropertyNames(Component.prototype));
-
-	// b \ a
-	// take all Component properties and remove any properties fround in PreactElement
 	const diff = Array.from(new Set([...b].filter((x) => !a.has(x))));
 
 	PreactElement.prototype = diff.reduce((acc, propertyName) => {

--- a/src/index.js
+++ b/src/index.js
@@ -8,11 +8,24 @@ export default function register(Component, tagName, propNames, options) {
 			options && options.shadow ? inst.attachShadow({ mode: 'open' }) : inst;
 		return inst;
 	}
+
 	PreactElement.prototype = Object.create(HTMLElement.prototype);
 	PreactElement.prototype.constructor = PreactElement;
 	PreactElement.prototype.connectedCallback = connectedCallback;
 	PreactElement.prototype.attributeChangedCallback = attributeChangedCallback;
 	PreactElement.prototype.disconnectedCallback = disconnectedCallback;
+
+	const a = new Set(Object.getOwnPropertyNames(PreactElement.prototype));
+	const b = new Set(Object.getOwnPropertyNames(Component.prototype));
+
+	// b \ a
+	// take all Component properties and remove any properties fround in PreactElement
+	const diff = Array.from(new Set([...b].filter((x) => !a.has(x))));
+
+	PreactElement.prototype = diff.reduce((acc, propertyName) => {
+		acc[propertyName] = Component.prototype[propertyName];
+		return acc;
+	}, PreactElement.prototype);
 
 	propNames =
 		propNames ||

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const lifecycleMethods = [
 	'shouldComponentUpdate',
 	'componentWillUpdate',
 	'getSnapshotBeforeUpdate',
-	'componentDidUpdate	',
+	'componentDidUpdate',
 ];
 
 const apiMethods = ['render'];

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -246,25 +246,32 @@ describe('web components', () => {
 		assert.equal(getShadowHTML(), '<p>Active theme: sunny</p>');
 	});
 
-	class Greeting extends Component {
-		static tagName = 'x-greeting';
-		static observedAttributes = ['name'];
-
-		hello() {
-			return 'hello world';
+	class Counter extends Component {
+		constructor() {
+			super();
+			this.counter = 0;
 		}
 
-		render({ name }) {
-			return <p>Hello, {name}!</p>;
+		whoami() {
+			return 'counter';
+		}
+
+		count() {
+			this.counter++;
+			return this.counter;
+		}
+
+		render() {
+			return <p>Count</p>;
 		}
 	}
 
-	registerElement(Greeting, 'x-greeting');
+	registerElement(Counter, 'x-counter');
 
 	it(`should mirror component methods`, async () => {
-		const cmp = document.createElement('x-greeting');
+		const cmp = document.createElement('x-counter');
 
-		expect(cmp.hello).to.not.be.undefined;
-		expect(cmp.hello()).to.eql('hello world');
+		expect(cmp.whoami).to.not.be.undefined;
+		expect(cmp.whoami()).to.eql('counter');
 	});
 });

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -261,7 +261,7 @@ describe('web components', () => {
 
 	registerElement(Greeting, 'x-greeting');
 
-	it(`should mirror components' methods`, async () => {
+	it(`should mirror component methods`, async () => {
 		const cmp = document.createElement('x-greeting');
 
 		expect(cmp.hello).to.not.be.undefined;

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -1,5 +1,5 @@
-import { assert } from '@open-wc/testing';
-import { h, createContext } from 'preact';
+import { assert, expect } from '@open-wc/testing';
+import { h, createContext, Component } from 'preact';
 import { useContext } from 'preact/hooks';
 import { act } from 'preact/test-utils';
 import registerElement from './index';
@@ -244,5 +244,27 @@ describe('web components', () => {
 			el.setAttribute('theme', 'sunny');
 		});
 		assert.equal(getShadowHTML(), '<p>Active theme: sunny</p>');
+	});
+
+	class Greeting extends Component {
+		static tagName = 'x-greeting';
+		static observedAttributes = ['name'];
+
+		hello() {
+			return 'hello world';
+		}
+
+		render({ name }) {
+			return <p>Hello, {name}!</p>;
+		}
+	}
+
+	registerElement(Greeting, 'x-greeting');
+
+	it(`should mirror components' methods`, async () => {
+		const cmp = document.createElement('x-greeting');
+
+		expect(cmp.hello).to.not.be.undefined;
+		expect(cmp.hello()).to.eql('hello world');
 	});
 });

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -256,11 +256,6 @@ describe('web components', () => {
 			return 'counter';
 		}
 
-		count() {
-			this.counter++;
-			return this.counter;
-		}
-
 		render() {
 			return <p>Count</p>;
 		}
@@ -268,7 +263,13 @@ describe('web components', () => {
 
 	registerElement(Counter, 'x-counter');
 
-	it(`should mirror component methods`, async () => {
+	it('should instantiate on document.createElement()', () => {
+		const cmp = document.createElement('x-counter');
+
+		expect(cmp.counter).to.eql(0);
+	});
+
+	it('should mirror component methods', () => {
 		const cmp = document.createElement('x-counter');
 
 		expect(cmp.whoami).to.not.be.undefined;


### PR DESCRIPTION
Custom elements are missing component methods.

Example:

```js
import { Component } from 'preact'
import register from 'preact-custom-element'

class Test extends Component {
  constructor() {
    super()
    this.state = { value: -1 }
  }

  getValue() {
    return this.state.value
  }

  // ...
}

register(Test, 'x-test')
```

Error:

```js
<x-test id="test1"></x-test>

// ...

document.getElementById('test1').getValue() // VM168:1 Uncaught TypeError: document.getElementById(...).getValue is not a function
```

This PR is an attempt at fixing the issue.