### PR TITLE
Fix: Preserve complex props across connectedCallback calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ export default function register(Component, tagName, propNames, options) {
 			},
 			set(v) {
 				if (this._vdom) {
+					this._props[name] = v;
 					this.attributeChangedCallback(name, null, v);
 				} else {
 					if (!this._props) this._props = {};

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -130,6 +130,33 @@ describe('web components', () => {
 			});
 			assert.equal(other, 1);
 		});
+
+		it('sets complex property after other property', () => {
+			const el = document.createElement('x-dummy-button');
+
+			// set simple property first
+			el.text = 'click me';
+
+			let clicks = 0;
+			const onClick = () => clicks++;
+			el.onClick = onClick;
+
+			assert.equal(el.text, 'click me');
+			assert.equal(el.onClick, onClick);
+
+			root.appendChild(el);
+			assert.equal(
+				root.innerHTML,
+				'<x-dummy-button text="click me"><button>click me</button></x-dummy-button>'
+			);
+
+			act(() => {
+				el.querySelector('button').click();
+			});
+
+			assert.equal(el.onClick, onClick);
+			assert.equal(clicks, 1);
+		});
 	});
 
 	function Foo({ text, children }) {


### PR DESCRIPTION
This PR fixes the issue, when complex prop is lost on repeated connectedCallback call.
It fixes it by saving all props into this._props.

The issue was that when complex prop was set as second or later prop (after vdom was created) we did not store it into `this._props` field.
Then it is missing when connectedCallback is called implicitly (when element inserted into DOM),
because we use there this._pros when rendering vdom; see: https://github.com/preactjs/preact-custom-element/blob/5790765ec0227ebb16add2f1469aef648e9f9f9e/src/index.js#L81

The simple props were not affected even if we set them as second or later prop because those are preserved in the attributes, and provided into vdom in connectedCallback, see: https://github.com/preactjs/preact-custom-element/blob/5790765ec0227ebb16add2f1469aef648e9f9f9e/src/index.js#L140

Fixes #69 