### PR TITLE
Update README to refer to register instead of CustomElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Previous versions (< 3.0.0) implemented the v0 proposal, which was only implemen
 
 ## Usage
 
-Import `register` and call it with your component, a tag name __\*__, and a list of attribute names you want to observe:
+Import `register` and call it with your component, a tag name<strong>*</strong>, and a list of attribute names you want to observe:
 
 ```javascript
 import register from 'preact-custom-element';

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Previous versions (< 3.0.0) implemented the v0 proposal, which was only implemen
 
 ## Usage
 
-Import `CustomElement` and call with your component a tag name __\*__, and a list of attribute names you want to observe:
+Import `register` and call it with your component, a tag name __\*__, and a list of attribute names you want to observe:
 
 ```javascript
 import register from 'preact-custom-element';


### PR DESCRIPTION
It looks like this reference was missed when the example code was switched to the `register` function.