### PR TITLE
Return the newly created HtmlElement class, as opposed to just "undef…

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,6 +43,7 @@ type Options =
  *   shadow: true,
  *   mode: 'closed'
  * });
+ * const klass = register(PreactComponent, 'my-component');
  * ```
  */
 export default function register(
@@ -50,4 +51,4 @@ export default function register(
 	tagName?: string,
 	propNames?: string[],
 	options?: Options
-): void;
+): HTMLElement;

--- a/src/index.js
+++ b/src/index.js
@@ -75,10 +75,12 @@ export default function register(Component, tagName, propNames, options) {
 		});
 	});
 
-	return customElements.define(
+	customElements.define(
 		tagName || Component.tagName || Component.displayName || Component.name,
 		PreactElement
 	);
+
+	return PreactElement;
 }
 
 function ContextProvider(props) {


### PR DESCRIPTION
It would make sense for `register` to return the newly created `HtmlElement` class instead of just [undefined](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#return_value).

```js
const klass = register(Component, 'element-tag');
```

vs

```js
register(Component, 'element-tag');
const klass = customElements.get('element-tag');
```

Just a little more ergonomic for those wanting to get a reference to the newly created class.