### PR TITLE
fix: expose correct types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import { h, cloneElement, render, hydrate } from 'preact';
 
 /**
  * @typedef {import('preact').FunctionComponent<any> | import('preact').ComponentClass<any> | import('preact').FunctionalComponent<any> } ComponentDefinition
- * @typedef {{ shadow: false } | { shadow: true, mode: 'open' | 'closed'}} Options
+ * @typedef {{ shadow: false } | { shadow: true, mode?: 'open' | 'closed' }} Options
  * @typedef {HTMLElement & { _root: ShadowRoot | HTMLElement, _vdomComponent: ComponentDefinition, _vdom: ReturnType<typeof import("preact").h> | null }} PreactCustomElement
  */
 


### PR DESCRIPTION
Since `mode` prop is definitely treated as an optional:

```javascript
export default function register(Component, tagName, propNames, options) {
	function PreactElement() {
		const inst = /** @type {PreactCustomElement} */ (
			Reflect.construct(HTMLElement, [], PreactElement)
		);
		inst._vdomComponent = Component;
		inst._root =
			options && options.shadow
				? inst.attachShadow({ mode: options.mode || 'open' })
				: inst;
		return inst;
	}
	....
```

 this behaviour should be reflected in the typedef as well since v4.4.0 is breaking for TypeScript users.