### PR TITLE
refactor: Switch to `.d.ts` for types

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "Node",
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "skipLibCheck": false,
+    "jsx": "react",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "Fragment",
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"module": "dist/preact-custom-element.esm.js",
 	"unpkg": "dist/preact-custom-element.umd.js",
 	"scripts": {
+		"prepare": "npx simple-git-hooks",
 		"build": "microbundle -f cjs,es,umd --no-generateTypes",
 		"lint": "eslint src/*.{js,jsx}",
 		"test": "wtr src/*.test.{js,jsx}",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"module": "dist/preact-custom-element.esm.js",
 	"unpkg": "dist/preact-custom-element.umd.js",
 	"scripts": {
-		"build": "microbundle -f cjs,es,umd",
+		"build": "microbundle -f cjs,es,umd --no-generateTypes",
 		"lint": "eslint src/*.{js,jsx}",
 		"test": "wtr src/*.test.{js,jsx}",
 		"prettier": "prettier **/*.{js,jsx} --write",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "4.4.0",
 	"description": "Wrap your component up as a custom element",
 	"source": "src/index.js",
-	"types": "dist/index.d.ts",
+	"types": "src/index.d.ts",
 	"main": "dist/preact-custom-element.js",
 	"module": "dist/preact-custom-element.esm.js",
 	"unpkg": "dist/preact-custom-element.umd.js",
@@ -51,6 +51,7 @@
 	"bugs": "https://github.com/preactjs/preact-custom-element/issues",
 	"homepage": "https://github.com/preactjs/preact-custom-element",
 	"files": [
+		"src",
 		"dist",
 		"LICENSE",
 		"package.json",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,34 @@ type Options =
 			adoptedStyleSheets?: CSSStyleSheet[];
 	  };
 
+/**
+ * Register a preact component as web-component.
+ *
+ * @example
+ * ```jsx
+ * // use custom web-component class
+ * class PreactWebComponent extends Component {
+ *   static tagName = 'my-web-component';
+ *   render() {
+ *     return <p>Hello world!</p>
+ *   }
+ * }
+ *
+ * register(PreactComponent);
+ *
+ * // use a preact component
+ * function PreactComponent({ prop }) {
+ *   return <p>Hello {prop}!</p>
+ * }
+ *
+ * register(PreactComponent, 'my-component');
+ * register(PreactComponent, 'my-component', ['prop']);
+ * register(PreactComponent, 'my-component', ['prop'], {
+ *   shadow: true,
+ *   mode: 'closed'
+ * });
+ * ```
+ */
 export default function register(
 	Component: AnyComponent,
 	tagName?: string,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,25 @@
+import { h, AnyComponent } from 'preact';
+
+type PreactCustomElement = HTMLElement & {
+	_root: ShadowRoot | HTMLElement;
+	_vdomComponent: AnyComponent;
+	_vdom: ReturnType<typeof h> | null;
+	_props: Record<string, unknown>;
+};
+
+type Options =
+	| {
+			shadow: false;
+	  }
+	| {
+			shadow: true;
+			mode?: 'open' | 'closed';
+			adoptedStyleSheets?: CSSStyleSheet[];
+	  };
+
+export default function register(
+	Component: AnyComponent,
+	tagName?: string,
+	propNames?: string[],
+	options?: Options
+): void;

--- a/src/index.js
+++ b/src/index.js
@@ -4,35 +4,9 @@ import { h, cloneElement, render, hydrate } from 'preact';
  * @typedef {import('./index.d.ts').PreactCustomElement} PreactCustomElement
  */
 
+
 /**
- * Register a preact component as web-component.
- *
  * @type {import('./index.d.ts').default}
- *
- * @example
- * ```jsx
- * // use custom web-component class
- * class PreactWebComponent extends Component {
- *   static tagName = 'my-web-component';
- *   render() {
- *     return <p>Hello world!</p>
- *   }
- * }
- *
- * register(PreactComponent);
- *
- * // use a preact component
- * function PreactComponent({ prop }) {
- *   return <p>Hello {prop}!</p>
- * }
- *
- * register(PreactComponent, 'my-component');
- * register(PreactComponent, 'my-component', ['prop']);
- * register(PreactComponent, 'my-component', ['prop'], {
- *   shadow: true,
- *   mode: 'closed'
- * });
- * ```
  */
 export default function register(Component, tagName, propNames, options) {
 	function PreactElement() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,16 @@
 import { h, cloneElement, render, hydrate } from 'preact';
 
 /**
- * @typedef {import('preact').FunctionComponent<any> | import('preact').ComponentClass<any> | import('preact').FunctionalComponent<any> } ComponentDefinition
- * @typedef {{ shadow: false } | { shadow: true, mode?: 'open' | 'closed', adoptedStyleSheets?: CSSStyleSheet[] }} Options
- * @typedef {HTMLElement & { _root: ShadowRoot | HTMLElement, _vdomComponent: ComponentDefinition, _vdom: ReturnType<typeof import("preact").h> | null }} PreactCustomElement
+ * @typedef {import('./index.d.ts').PreactCustomElement} PreactCustomElement
  */
 
 /**
  * Register a preact component as web-component.
- * @param {ComponentDefinition} Component The preact component to register
- * @param {string} [tagName] The HTML element tag-name (must contain a hyphen and be lowercase)
- * @param {string[]} [propNames] HTML element attributes to observe
- * @param {Options} [options] Additional element options
+ *
+ * @type {import('./index.d.ts').default}
+ *
  * @example
- * ```ts
+ * ```jsx
  * // use custom web-component class
  * class PreactWebComponent extends Component {
  *   static tagName = 'my-web-component';


### PR DESCRIPTION
Currently Microbundle is generating types for us from the JSDoc types which, IMO, probably isn't ideal. Builds are slightly slower, they're a bit harder to read, and Microbundle keeps the original JSDoc type comments in the generated `.d.ts` which are entirely redundant and makes it quite hard for consumers to read if they ever need to.

Our types are so simple that a manual `.d.ts` I think is a pretty objective improvement.

---

Also adds a `jsconfig.json` -- I don't know about other folks but my editor won't type check without it or a `tsconfig.json` w/ `allowJS` and `checkJS` set. There's a few type errors that are mostly expected, but also caught one that could be easily addressed while writing this (`_props` was missing, but consumed, from `PreactCustomElement`)