### PR TITLE
chore: Add '@types/mocha' for our test suite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@open-wc/testing": "^4.0.0",
+				"@types/mocha": "^10.0.10",
 				"@web/dev-server-esbuild": "^1.0.4",
 				"@web/test-runner": "^0.20.2",
 				"eslint": "^7.7.0",
@@ -3484,6 +3485,13 @@
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
 			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
 			"dev": true
+		},
+		"node_modules/@types/mocha": {
+			"version": "10.0.10",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+			"integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "20.5.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 	},
 	"devDependencies": {
 		"@open-wc/testing": "^4.0.0",
+		"@types/mocha": "^10.0.10",
 		"@web/dev-server-esbuild": "^1.0.4",
 		"@web/test-runner": "^0.20.2",
 		"eslint": "^7.7.0",


### PR DESCRIPTION
Now that we have working type checking for the project (#100), turns out we're missing types for `describe`/`it`