### PR TITLE
chore: Fix "repository" metadata format for NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
 			]
 		}
 	},
-	"repository": "preactjs/preact-custom-element",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/preactjs/preact-custom-element.git"
+	},
 	"keywords": [
 		"preact",
 		"web",


### PR DESCRIPTION
Can go in after 4.5.0 is published, but NPM doesn't like our format and tells us to correct it to this.