### PR TITLE
fix(types): fix type inference issue of register method

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -46,8 +46,8 @@ type Options =
  * const klass = register(PreactComponent, 'my-component');
  * ```
  */
-export default function register(
-	Component: AnyComponent,
+export default function register<P = {}, S = {}>(
+	Component: AnyComponent<P, S>,
 	tagName?: string,
 	propNames?: string[],
 	options?: Options


### PR DESCRIPTION
With the declaration of `Component` as an `AnyComponent` with `preact-custom-element` in version `4.5.0` the typescript compiler complains about not compatible types:
<img width="947" height="457" alt="image" src="https://github.com/user-attachments/assets/e4424459-e054-4bc0-a94b-92cd8f8fd895" />

This issue is caused because register function doesn’t define generic type parameters, so TypeScript doesn’t know how to infer P and S. By doing so TypeScript is happy again:

<img width="947" height="785" alt="image" src="https://github.com/user-attachments/assets/d6d659f4-96e9-466a-b5b6-a6956d1c8af1" />