### PR TITLE
types: Limit observed attributes to keys of component props

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -49,6 +49,6 @@ type Options =
 export default function register<P = {}, S = {}>(
 	Component: AnyComponent<P, S>,
 	tagName?: string,
-	propNames?: string[],
+	propNames?: (keyof P)[],
 	options?: Options
 ): HTMLElement;


### PR DESCRIPTION
Credit to @alextompkins for the idea & impl, limits the `observedAttributes` array to known props on the component.

Because we don't allow users to set their own `attributeChangedCallback`, and because all changed attributes end up as props on the component, this seems like a pretty reasonable & safe change. Some folks could be watching arbitrary attributes that aren't declared as props on the component, and whilst not wrong per se, that does feel like a weird situation that it's okay to break.