### PR TITLE
chore: update dependencies and add TypeScript support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,27 @@
 {
 	"name": "preact-custom-element",
-	"version": "4.4.0",
+	"version": "4.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "preact-custom-element",
-			"version": "4.4.0",
+			"version": "4.5.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@open-wc/testing": "^4.0.0",
 				"@types/mocha": "^10.0.10",
 				"@web/dev-server-esbuild": "^1.0.4",
 				"@web/test-runner": "^0.20.2",
+				"@web/test-runner-puppeteer": "^0.18.0",
 				"eslint": "^7.7.0",
 				"eslint-config-developit": "^1.2.0",
 				"microbundle": "^0.15.1",
 				"nano-staged": "^0.8.0",
 				"preact": "^10.27.1",
 				"prettier": "^2.1.1",
-				"simple-git-hooks": "^2.13.1"
+				"simple-git-hooks": "^2.13.1",
+				"typescript": "^5.9.2"
 			},
 			"peerDependencies": {
 				"preact": ">= 10.25.0 || >=11.0.0-0"
@@ -2714,11 +2716,10 @@
 			}
 		},
 		"node_modules/@puppeteer/browsers": {
-			"version": "2.10.8",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.8.tgz",
-			"integrity": "sha512-f02QYEnBDE0p8cteNoPYHHjbDuwyfbe4cCIVlNi8/MRicIxFW4w4CfgU0LNgWEID6s06P+hRJ1qjpBLMhPRCiQ==",
+			"version": "2.10.9",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.9.tgz",
+			"integrity": "sha512-kUGHwABarVhvMP+zhW5zvDA7LmGcd4TwrTEBwcTQic5EebUqaK5NjC0UXLJepIFVGsr2N/Z8NJQz2JYGo1ZwxA==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"dependencies": {
 				"debug": "^4.4.1",
 				"extract-zip": "^2.0.1",
@@ -2733,60 +2734,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@puppeteer/browsers/node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@puppeteer/browsers/node_modules/y18n": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@puppeteer/browsers/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@rollup/plugin-alias": {
@@ -4058,6 +4005,20 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@web/test-runner-puppeteer": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@web/test-runner-puppeteer/-/test-runner-puppeteer-0.18.0.tgz",
+			"integrity": "sha512-pc0gADGjqflSRIZQehwD9INKUY1DZ92eWJwuVwZXzKxr5soniT/Bknv2hT5ttpJ5P7ILuCyjJyq5IjKzPBFUXg==",
+			"dev": true,
+			"dependencies": {
+				"@web/test-runner-chrome": "^0.18.0",
+				"@web/test-runner-core": "^0.13.0",
+				"puppeteer": "^24.0.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/@web/test-runner/node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4984,6 +4945,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/clone": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -5601,11 +5576,10 @@
 			}
 		},
 		"node_modules/devtools-protocol": {
-			"version": "0.0.1475386",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
-			"integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
-			"dev": true,
-			"license": "BSD-3-Clause"
+			"version": "0.0.1495869",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
+			"integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
+			"dev": true
 		},
 		"node_modules/diff": {
 			"version": "5.1.0",
@@ -5788,6 +5762,15 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/error-ex": {
@@ -10195,18 +10178,39 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/puppeteer-core": {
-			"version": "24.18.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.18.0.tgz",
-			"integrity": "sha512-As0BvfXxek2MbV0m7iqBmQKFnfSrzSvTM4zGipjd4cL+9f2Ccgut6RvHlc8+qBieKHqCMFy9BSI4QyveoYXTug==",
+		"node_modules/puppeteer": {
+			"version": "24.20.0",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.20.0.tgz",
+			"integrity": "sha512-iLnLV9oHKKAujmxiSxRWKfcT1q2COu0g1N9iU2TCp1MlmsyjgNAkcBOR3cAOqKb5UTiVPIGG4z5PO5yfpYZ6jA==",
 			"dev": true,
-			"license": "Apache-2.0",
+			"hasInstallScript": true,
 			"dependencies": {
-				"@puppeteer/browsers": "2.10.8",
+				"@puppeteer/browsers": "2.10.9",
+				"chromium-bidi": "8.0.0",
+				"cosmiconfig": "^9.0.0",
+				"devtools-protocol": "0.0.1495869",
+				"puppeteer-core": "24.20.0",
+				"typed-query-selector": "^2.12.0"
+			},
+			"bin": {
+				"puppeteer": "lib/cjs/puppeteer/node/cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/puppeteer-core": {
+			"version": "24.20.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.20.0.tgz",
+			"integrity": "sha512-n0y/f8EYyZt4yEJkjP3Vrqf9A4qa3uYpKYdsiedIY4bxIfTw1aAJSpSVPmWBPlr1LO4cNq2hGNIBWKPhvBF68w==",
+			"dev": true,
+			"dependencies": {
+				"@puppeteer/browsers": "2.10.9",
 				"chromium-bidi": "8.0.0",
 				"debug": "^4.4.1",
-				"devtools-protocol": "0.0.1475386",
+				"devtools-protocol": "0.0.1495869",
 				"typed-query-selector": "^2.12.0",
+				"webdriver-bidi-protocol": "0.2.8",
 				"ws": "^8.18.3"
 			},
 			"engines": {
@@ -10233,6 +10237,50 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/puppeteer/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"node_modules/puppeteer/node_modules/cosmiconfig": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+			"dev": true,
+			"dependencies": {
+				"env-paths": "^2.2.1",
+				"import-fresh": "^3.3.0",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/puppeteer/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/qs": {
@@ -10813,56 +10861,6 @@
 				"rollup": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/rollup-plugin-visualizer/node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/rollup-plugin-visualizer/node_modules/y18n": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/rollup-plugin-visualizer/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/rollup-plugin-visualizer/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/rollup-pluginutils": {
@@ -11909,11 +11907,10 @@
 			"license": "MIT"
 		},
 		"node_modules/typescript": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -12092,6 +12089,12 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/webdriver-bidi-protocol": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.2.8.tgz",
+			"integrity": "sha512-KPvtVAIX8VHjLZH1KHT5GXoOaPeb0Ju+JlAcdshw6Z/gsmRtLoxt0Hw99PgJwZta7zUQaAUIHHWDRkzrPHsQTQ==",
+			"dev": true
 		},
 		"node_modules/webidl-conversions": {
 			"version": "7.0.0",
@@ -12276,6 +12279,15 @@
 				}
 			}
 		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -12289,6 +12301,33 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -69,13 +69,15 @@
 		"@types/mocha": "^10.0.10",
 		"@web/dev-server-esbuild": "^1.0.4",
 		"@web/test-runner": "^0.20.2",
+		"@web/test-runner-puppeteer": "^0.18.0",
 		"eslint": "^7.7.0",
 		"eslint-config-developit": "^1.2.0",
 		"microbundle": "^0.15.1",
 		"nano-staged": "^0.8.0",
 		"preact": "^10.27.1",
 		"prettier": "^2.1.1",
-		"simple-git-hooks": "^2.13.1"
+		"simple-git-hooks": "^2.13.1",
+		"typescript": "^5.9.2"
 	},
 	"simple-git-hooks": {
 		"pre-commit": "npx nano-staged"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,6 +15,7 @@ type Options =
 			shadow: true;
 			mode?: 'open' | 'closed';
 			adoptedStyleSheets?: CSSStyleSheet[];
+			serializable?: boolean;
 	  };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,341 @@
+import {
+	h,
+	cloneElement,
+	render,
+	hydrate,
+	Fragment,
+	AnyComponent,
+	ComponentConstructor,
+} from 'preact';
+
+type PreactCustomElement = HTMLElement & {
+	_root: ShadowRoot | HTMLElement;
+	_vdomComponent: AnyComponent;
+	_vdom: ReturnType<typeof h> | null;
+	_props: Record<string, unknown>;
+};
+
+type Options =
+	| {
+			shadow: false;
+	  }
+	| {
+			shadow: true;
+			mode?: 'open' | 'closed';
+			adoptedStyleSheets?: CSSStyleSheet[];
+			serializable?: boolean;
+	  };
+
+interface PrivateData {
+	vdomComponent: AnyComponent;
+	props: Record<string, unknown> | null;
+	vdom: ReturnType<typeof h> | null;
+}
+
+interface SlotProps {
+	useFragment?: boolean;
+	name?: string;
+	[key: string]: any;
+}
+
+/**
+ * Creates a shadow root with serializable support if available
+ */
+function createShadowRoot(
+	element: HTMLElement,
+	options: Extract<Options, { shadow: true }>
+): ShadowRoot {
+	const shadowOptions: ShadowRootInit & { serializable?: boolean } = {
+		mode: options.mode || 'open',
+	};
+
+	// Add serializable option if requested and supported
+	if (options.serializable) {
+		shadowOptions.serializable = true;
+	}
+
+	try {
+		return element.attachShadow(shadowOptions);
+	} catch (e) {
+		// Fallback for browsers that don't support serializable
+		return element.attachShadow({ mode: options.mode || 'open' });
+	}
+}
+
+// WeakMaps for private instance data
+const privateData = new WeakMap<HTMLElement, PrivateData>();
+const PRIMITIVE_TYPES = new Set<string>(['string', 'boolean', 'number']);
+
+/**
+ * Register a preact component as web-component.
+ */
+export default function register<P = {}, S = {}>(
+	Component: AnyComponent<P, S>,
+	tagName?: string,
+	propNames?: (keyof P)[],
+	options?: Options
+): typeof HTMLElement {
+	class PreactElement extends HTMLElement implements PreactCustomElement {
+		_root: ShadowRoot | HTMLElement;
+
+		constructor() {
+			super();
+
+			// Initialize private data
+			privateData.set(this, {
+				vdomComponent: Component as AnyComponent,
+				props: null,
+				vdom: null,
+			});
+
+			this._root = options?.shadow ? createShadowRoot(this, options) : this;
+
+			if (options?.shadow && options.adoptedStyleSheets) {
+				(this._root as ShadowRoot).adoptedStyleSheets =
+					options.adoptedStyleSheets;
+			}
+		}
+
+		connectedCallback(): void {
+			connectedCallback.call(this, options);
+		}
+
+		attributeChangedCallback(
+			name: string,
+			oldValue: string | null,
+			newValue: string | null
+		): void {
+			const data = privateData.get(this);
+			if (!data?.vdom) return;
+
+			// Attributes use `null` as an empty value whereas `undefined` is more
+			// common in pure JS components, especially with default parameters.
+			const processedNewValue = newValue == null ? undefined : newValue;
+			const props: Record<string, any> = {};
+			props[name] = processedNewValue;
+			props[toCamelCase(name)] = processedNewValue;
+			data.vdom = cloneElement(data.vdom, props);
+			render(data.vdom, this._root);
+		}
+
+		disconnectedCallback(): void {
+			const data = privateData.get(this);
+			if (data) {
+				data.vdom = null;
+			}
+			render(null, this._root);
+		}
+
+		// Getter and setter for vdom
+		get _vdom(): ReturnType<typeof h> | null {
+			return privateData.get(this)?.vdom ?? null;
+		}
+
+		set _vdom(value: ReturnType<typeof h> | null) {
+			const data = privateData.get(this);
+			if (data) {
+				data.vdom = value;
+			}
+		}
+
+		// Getter and setter for props
+		get _props(): Record<string, unknown> {
+			return privateData.get(this)?.props ?? {};
+		}
+
+		set _props(value: Record<string, unknown>) {
+			const data = privateData.get(this);
+			if (data) {
+				data.props = value;
+			}
+		}
+
+		get _vdomComponent(): AnyComponent {
+			return (
+				privateData.get(this)?.vdomComponent ?? (Component as AnyComponent)
+			);
+		}
+
+		static observedAttributes: string[];
+		static formAssociated?: boolean;
+	}
+
+	/**
+	 * @type {string[]}
+	 */
+	const resolvedPropNames: string[] =
+		(propNames as string[]) ||
+		(Component as any).observedAttributes ||
+		Object.keys((Component as any).propTypes || {});
+	PreactElement.observedAttributes = resolvedPropNames;
+
+	if ((Component as any).formAssociated) {
+		PreactElement.formAssociated = true;
+	}
+
+	// Keep DOM properties and Preact props in sync
+	resolvedPropNames.forEach((name: string) => {
+		Object.defineProperty(PreactElement.prototype, name, {
+			get(this: PreactElement) {
+				const data = privateData.get(this);
+				return (data?.vdom?.props as any)?.[name] ?? data?.props?.[name];
+			},
+			set(this: PreactElement, v: any) {
+				const data = privateData.get(this);
+				if (data?.vdom) {
+					this.attributeChangedCallback(name, null, v);
+				} else if (data) {
+					if (!data.props) data.props = {};
+					data.props[name] = v;
+				}
+
+				// Reflect property changes to attributes if the value is a primitive
+				const type = typeof v;
+				if (v == null || PRIMITIVE_TYPES.has(type)) {
+					this.setAttribute(name, v);
+				}
+			},
+			enumerable: true,
+			configurable: true,
+		});
+	});
+
+	customElements.define(
+		tagName ||
+			(Component as any).tagName ||
+			(Component as any).displayName ||
+			(Component as any).name,
+		PreactElement
+	);
+
+	return PreactElement as any;
+}
+
+function ContextProvider(this: any, props: any) {
+	this.getChildContext = () => props.context;
+	// eslint-disable-next-line no-unused-vars
+	const { context, children, ...rest } = props;
+	return cloneElement(children, rest);
+}
+
+/**
+ * @this {PreactCustomElement}
+ */
+function connectedCallback(this: PreactCustomElement, options?: Options): void {
+	// Obtain a reference to the previous context by pinging the nearest
+	// higher up node that was rendered with Preact. If one Preact component
+	// higher up receives our ping, it will set the `detail` property of
+	// our custom event. This works because events are dispatched
+	// synchronously.
+	const event = new CustomEvent('_preact', {
+		detail: {},
+		bubbles: true,
+		cancelable: true,
+	});
+	this.dispatchEvent(event as any);
+	// Context property is added dynamically by event listeners
+	const context = (event.detail as any)?.context;
+
+	const data = privateData.get(this);
+	if (data) {
+		data.vdom = h(
+			ContextProvider as any,
+			{ ...data.props, context } as any,
+			toVdom(this, data.vdomComponent, options)
+		);
+		(this.hasAttribute('hydrate') ? hydrate : render)(data.vdom, this._root);
+	}
+}
+
+/**
+ * Camel-cases a string
+ */
+function toCamelCase(str: string): string {
+	return str.replace(/-(\w)/g, (_, c) => (c ? c.toUpperCase() : ''));
+}
+
+/**
+ * Pass an event listener to each `<slot>` that "forwards" the current
+ * context value to the rendered child. The child will trigger a custom
+ * event, where will add the context value to. Because events work
+ * synchronously, the child can immediately pull of the value right
+ * after having fired the event.
+ */
+const slotControllers = new WeakMap<any, AbortController>();
+
+function Slot(this: any, props: SlotProps, context: any) {
+	const ref = (r: HTMLElement | null) => {
+		const controller = slotControllers.get(this);
+
+		if (!r) {
+			// Cleanup: abort the controller to remove all listeners
+			if (controller) {
+				controller.abort();
+				slotControllers.delete(this);
+			}
+		} else {
+			// Setup: create new AbortController for this slot
+			const newController = new AbortController();
+			slotControllers.set(this, newController);
+
+			const listener = (event: Event) => {
+				event.stopPropagation();
+				// Context is added dynamically to event detail
+				(event as any).detail.context = context;
+			};
+
+			r.addEventListener('_preact', listener, {
+				signal: newController.signal,
+			});
+		}
+	};
+
+	const { useFragment, ...rest } = props;
+	return h(useFragment ? Fragment : 'slot', { ...rest, ref } as any);
+}
+
+function toVdom(
+	element: HTMLElement,
+	nodeName: AnyComponent | null,
+	options?: Options
+): ReturnType<typeof h> | string | null {
+	if ((element as any).nodeType === 3) return (element as any).data;
+	if ((element as any).nodeType !== 1) return null;
+
+	const children: any[] = [];
+	const props: Record<string, any> = {};
+	const attributes = element.attributes;
+	const childNodes = element.childNodes;
+
+	// Process attributes
+	for (let i = attributes.length; i--; ) {
+		if (attributes[i].name !== 'slot') {
+			props[attributes[i].name] = attributes[i].value;
+			props[toCamelCase(attributes[i].name)] = attributes[i].value;
+		}
+	}
+
+	// Process child nodes
+	for (let i = childNodes.length; i--; ) {
+		const vnode = toVdom(childNodes[i] as HTMLElement, null, options);
+		// Move slots correctly
+		const name = (childNodes[i] as any).slot;
+		if (name) {
+			props[name] = h(Slot, { name }, vnode);
+		} else {
+			children[i] = vnode;
+		}
+	}
+
+	const shadow = !!(options && options.shadow);
+
+	// Only wrap the topmost node with a slot
+	const wrappedChildren = nodeName
+		? h(Slot, { useFragment: !shadow }, children)
+		: children;
+
+	if (!shadow && nodeName) {
+		element.innerHTML = '';
+	}
+	return h(nodeName || element.nodeName.toLowerCase(), props, wrappedChildren);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"lib": ["ES2020", "DOM"],
+		"module": "ESNext",
+		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"jsx": "react-jsx",
+		"jsxImportSource": "preact",
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true
+	},
+	"include": [
+		"src/**/*"
+	],
+	"exclude": [
+		"node_modules",
+		"dist"
+	]
+}


### PR DESCRIPTION
- Bump version of preact-custom-element to 4.5.0
- Add @web/test-runner-puppeteer as a dev dependency
- Add TypeScript as a dev dependency
- Update package-lock.json with new versions of dependencies
- Enhance index.d.ts to include serializable option in Options type
- Refactor index.js to support serializable shadow roots and improve private data handling
- Introduce index.ts for TypeScript support with type definitions
- Update tsconfig.json to include necessary compiler options and settings